### PR TITLE
Create simplified template parts to be more user-friendly

### DIFF
--- a/template_parts/Bids_modality_agnostic/participant-animal-short.json
+++ b/template_parts/Bids_modality_agnostic/participant-animal-short.json
@@ -2,7 +2,7 @@
   "elabftw": {
     "extra_fields_groups": [
       {
-        "id": "2",
+        "id": 1,
         "name": "GENERIC_BIDS_PARTICIPANT"
       }
     ]
@@ -11,7 +11,7 @@
     "participant_id": {
       "type": "text",
       "value": "",
-      "group_id": 2,
+      "group_id": 1,
       "position": 0,
       "description": "Participant's ID (subject number or animal name etc.). It will define the BIDS directory name: sub-participant_id.",
       "blank_value_on_duplicate": false
@@ -19,7 +19,7 @@
     "participant_guid": {
       "type": "text",
       "value": "",
-      "group_id": 2,
+      "group_id": 1,
       "position": 1,
       "description": "The Globally Unique IDentifier (GUID) of the participant, if it exists",
       "blank_value_on_duplicate": false
@@ -27,9 +27,9 @@
     "species": {
       "type": "text",
       "value": "",
-      "group_id": 2,
+      "group_id": 1,
       "position": 2,
-	"description": "Species (from the NCBI Taxonomy), e.g., 'Macaca mulatta', 'Rattus norvegicusmus')",
+      "description": "Species (from the NCBI Taxonomy), e.g., 'Macaca mulatta', 'Rattus norvegicusmus')",
       "blank_value_on_duplicate": false
     },
     "age": {
@@ -40,7 +40,7 @@
         "months"
       ],
       "value": "",
-      "group_id": 2,
+      "group_id": 1,
       "position": 3,
       "description": "Age in years or months, e.g., '42' or '0.4'",
       "blank_value_on_duplicate": false
@@ -52,7 +52,7 @@
         "male",
         "other"
       ],
-      "group_id": 2,
+      "group_id": 1,
       "position": 4,
       "description": "Participant's sex",
       "blank_value_on_duplicate": false
@@ -60,10 +60,10 @@
     "strain": {
       "type": "text",
       "value": "",
-      "group_id": 2,
+      "group_id": 1,
       "position": 5,
       "description": "The strain of the subject",
       "blank_value_on_duplicate": false
-    },
+    }
   }
 }

--- a/template_parts/Bids_modality_agnostic/participant-animal-short.json
+++ b/template_parts/Bids_modality_agnostic/participant-animal-short.json
@@ -2,7 +2,7 @@
   "elabftw": {
     "extra_fields_groups": [
       {
-        "id": "",
+        "id": "2",
         "name": "GENERIC_BIDS_PARTICIPANT"
       }
     ]

--- a/template_parts/Bids_modality_agnostic/participant-animal-short.json
+++ b/template_parts/Bids_modality_agnostic/participant-animal-short.json
@@ -1,0 +1,69 @@
+{
+  "elabftw": {
+    "extra_fields_groups": [
+      {
+        "id": "",
+        "name": "GENERIC_BIDS_PARTICIPANT"
+      }
+    ]
+  },
+  "extra_fields": {
+    "participant_id": {
+      "type": "text",
+      "value": "",
+      "group_id": 2,
+      "position": 0,
+      "description": "Participant's ID (subject number or animal name etc.). It will define the BIDS directory name: sub-participant_id.",
+      "blank_value_on_duplicate": false
+    },
+    "participant_guid": {
+      "type": "text",
+      "value": "",
+      "group_id": 2,
+      "position": 1,
+      "description": "The Globally Unique IDentifier (GUID) of the participant, if it exists",
+      "blank_value_on_duplicate": false
+    },
+    "species": {
+      "type": "text",
+      "value": "",
+      "group_id": 2,
+      "position": 2,
+	"description": "Species (from the NCBI Taxonomy), e.g., 'Macaca mulatta', 'Rattus norvegicusmus')",
+      "blank_value_on_duplicate": false
+    },
+    "age": {
+      "type": "number",
+      "unit": "",
+      "units": [
+        "years",
+        "months"
+      ],
+      "value": "",
+      "group_id": 2,
+      "position": 3,
+      "description": "Age in years or months, e.g., '42' or '0.4'",
+      "blank_value_on_duplicate": false
+    },
+    "sex": {
+      "type": "radio",
+      "options": [
+        "female",
+        "male",
+        "other"
+      ],
+      "group_id": 2,
+      "position": 4,
+      "description": "Participant's sex",
+      "blank_value_on_duplicate": false
+    },
+    "strain": {
+      "type": "text",
+      "value": "",
+      "group_id": 2,
+      "position": 5,
+      "description": "The strain of the subject",
+      "blank_value_on_duplicate": false
+    },
+  }
+}

--- a/template_parts/Bids_modality_agnostic/participant-human-short.json
+++ b/template_parts/Bids_modality_agnostic/participant-human-short.json
@@ -2,7 +2,7 @@
   "elabftw": {
     "extra_fields_groups": [
       {
-        "id": "",
+        "id": 2,
         "name": "GENERIC_BIDS_PARTICIPANT"
       }
     ]

--- a/template_parts/Bids_modality_agnostic/participant-human-short.json
+++ b/template_parts/Bids_modality_agnostic/participant-human-short.json
@@ -1,0 +1,69 @@
+{
+  "elabftw": {
+    "extra_fields_groups": [
+      {
+        "id": "",
+        "name": "GENERIC_BIDS_PARTICIPANT"
+      }
+    ]
+  },
+  "extra_fields": {
+    "participant_id": {
+      "type": "text",
+      "value": "",
+      "group_id": 2,
+      "position": 0,
+      "description": "Participant's ID (subject number or animal name etc.). It will define the BIDS directory name: sub-participant_id."
+    },
+    "participant_guid": {
+      "type": "text",
+      "value": "",
+      "group_id": 2,
+      "position": 1,
+      "description": "The Globally Unique IDentifier (GUID) of the participant, if it exists"
+    },
+    "age": {
+      "type": "number",
+      "unit": "",
+      "units": [
+        "years",
+        "months"
+      ],
+      "value": "",
+      "group_id": 2,
+      "position": 2,
+      "description": "Age in years or months, e.g., '42' or '0.4'"
+    },
+    "sex": {
+      "type": "radio",
+      "options": [
+        "female",
+        "male",
+        "other"
+      ],
+      "group_id": 2,
+      "position": 3,
+      "description": "Participant's sex"
+    },
+    "group": {
+      "type": "text",
+      "value": "",
+      "group_id": 2,
+      "position": 4,
+      "description": "Experimental group (ex: \"control\", or \"patient\", or \"with training\" etc.)"
+    },
+    "handedness": {
+      "type": "radio",
+      "value": "left",
+      "options": [
+        "left",
+        "right",
+        "ambidextrous",
+        "unknown"
+      ],
+      "group_id": 2,
+      "position": 5,
+      "description": "Participant's handedness  e.g., 'left', 'right', or 'ambidextrous'"
+    }
+  }
+}

--- a/template_parts/Bids_modality_agnostic/project-short.json
+++ b/template_parts/Bids_modality_agnostic/project-short.json
@@ -13,7 +13,7 @@
             "value": "",
             "group_id": 1,
             "position": 0,
-            "description": "Project name (should be identical to the project tag)."
+            "description": "Project name (should be identical to the project tag).",
 	    "blank_value_on_duplicate": false
         },
         "Experimenters": {
@@ -21,15 +21,15 @@
             "value": "",
             "group_id": 1,
             "position": 1,
-            "description": "List of individuals who present during the recordings."
+            "description": "List of individuals present during the recordings.",
 	    "blank_value_on_duplicate": false
         },
         "Ethical Protocol Identifier": {
             "type": "text",
-            "value": "defaut format in '5X-16X-vX'",
+            "value": "",
             "group_id": 1,
             "position": 2,
-            "description": "The official ethical protocol id."
+            "description": "The official ethical protocol id.",
 	    "blank_value_on_duplicate": false
         }
     }

--- a/template_parts/Bids_modality_agnostic/project-short.json
+++ b/template_parts/Bids_modality_agnostic/project-short.json
@@ -32,26 +32,5 @@
             "description": "The official ethical protocol id."
 	    "blank_value_on_duplicate": false
         }
-        "DatasetDOI": {
-            "type": "text",
-            "value": "",
-            "group_id": 1,
-            "position": 2,
-            "description": "The Digital Object Identifier of the dataset (not the corresponding paper)."
-        },
-        "DatasetLinks": {
-            "type": "text",
-            "value": "",
-            "group_id": 1,
-            "position": 5,
-            "description": "Used to map a given <dataset-name> from a BIDS URI of the form bids:"
-        },
-        "GeneratedBy": {
-            "type": "text",
-            "value": "",
-            "group_id": 1,
-            "position": 4,
-            "description": "Used to specify provenance of the dataset."
-        },
     }
 }

--- a/template_parts/Bids_modality_agnostic/project.json
+++ b/template_parts/Bids_modality_agnostic/project.json
@@ -13,7 +13,7 @@
             "value": "",
             "group_id": 1,
             "position": 0,
-            "description": "Project name (should be identical to the project tag)."
+            "description": "Project name (should be identical to the project tag).",
 	    "blank_value_on_duplicate": false
         },
         "Experimenters": {
@@ -21,17 +21,17 @@
             "value": "",
             "group_id": 1,
             "position": 1,
-            "description": "List of individuals who present during the recordings."
+            "description": "List of individuals present during the recordings.",
 	    "blank_value_on_duplicate": false
         },
         "Ethical Protocol Identifier": {
             "type": "text",
-            "value": "defaut format in '5X-16X-vX'",
+            "value": "",
             "group_id": 1,
             "position": 2,
-            "description": "The official ethical protocol id."
+            "description": "The official ethical protocol id.",
 	    "blank_value_on_duplicate": false
-        }
+        },
         "DatasetDOI": {
             "type": "text",
             "value": "",
@@ -52,6 +52,6 @@
             "group_id": 1,
             "position": 4,
             "description": "Used to specify provenance of the dataset."
-        },
+        }
     }
 }


### PR DESCRIPTION
For now, I've just added a new template part, shorter, and dedicated to human subjects... You can review it, test the template part to see if it is usable with elabforms etc.

I will add other ones later...

(and for info, for now, this is only a "Draft pull request"... we will convert it to a mergeable pull request when all the simplified template parts will be available)