### PR TITLE
Update of several template parts to move forward to a finalized full template for confocal microscopy

### DIFF
--- a/template_parts/Bids_modality_agnostic/GENERAL_participant-animal-short.json
+++ b/template_parts/Bids_modality_agnostic/GENERAL_participant-animal-short.json
@@ -66,5 +66,13 @@
       "description": "The strain of the subject",
       "blank_value_on_duplicate": false
     }
+    "genotype": {
+      "type": "text",
+      "value": "",
+      "group_id": 1,
+      "position": 6,
+      "description": "Genotype of the animal",
+      "blank_value_on_duplicate": false
+    }
   }
 }

--- a/template_parts/Bids_modality_agnostic/GENERAL_participant-animal-short.json
+++ b/template_parts/Bids_modality_agnostic/GENERAL_participant-animal-short.json
@@ -37,7 +37,8 @@
       "unit": "",
       "units": [
         "years",
-        "months"
+        "months",
+	"days"
       ],
       "value": "",
       "group_id": 1,

--- a/template_parts/Bids_modality_agnostic/GENERAL_participant-animal-short.json
+++ b/template_parts/Bids_modality_agnostic/GENERAL_participant-animal-short.json
@@ -65,7 +65,7 @@
       "position": 5,
       "description": "The strain of the subject",
       "blank_value_on_duplicate": false
-    }
+    },
     "genotype": {
       "type": "text",
       "value": "",

--- a/template_parts/Bids_modality_agnostic/GENERAL_sample.json
+++ b/template_parts/Bids_modality_agnostic/GENERAL_sample.json
@@ -47,6 +47,5 @@
       "position": 5,
       "description": "sample-<label> entity from which a sample is derived, e.g., sample-cell02 is derived from sample-slice01."
     }
-
   }
 }

--- a/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_common.json
+++ b/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_common.json
@@ -7,19 +7,11 @@
             }
         ]
     },
-        "NumericalAperture": {
-            "type": "number",
-            "value": "",
-            "group_id": 1,
-            "position": 1,
-            "description": "Lens numerical aperture (e.g. 1.4).",
-            "blank_value_on_duplicate": false
-        },
         "BodyPart": {
             "type": "text",
             "value": "",
             "group_id": 1,
-            "position": 2,
+            "position": 1,
             "description": "Body part of the organ / region scanned (e.g. BRAIN).",
             "blank_value_on_duplicate": false
         },
@@ -27,7 +19,7 @@
             "type": "text",
             "value": "",
             "group_id": 1,
-            "position": 3,
+            "position": 2,
             "description": "Additional details about body part or location.",
             "blank_value_on_duplicate": false
         },
@@ -40,7 +32,7 @@
                 "in vitro"
             ],
             "group_id": 1,
-            "position": 4,
+            "position": 3,
             "description": "Environment in which the sample was imaged.",
             "blank_value_on_duplicate": false
         },
@@ -48,7 +40,7 @@
             "type": "text",
             "value": "",
             "group_id": 1,
-            "position": 5,
+            "position": 4,
             "description": "Description of the tissue sample embedding.",
             "blank_value_on_duplicate": false
         },
@@ -56,7 +48,7 @@
             "type": "text",
             "value": "",
             "group_id": 1,
-            "position": 6,
+            "position": 5,
             "description": "Description of the tissue sample fixation.",
             "blank_value_on_duplicate": false
         },
@@ -64,7 +56,7 @@
             "type": "text",
             "value": "",
             "group_id": 1,
-            "position": 7,
+            "position": 6,
             "description": "Tissue sample staining(s). (within brackets if more than one)",
             "blank_value_on_duplicate": false
         },
@@ -72,7 +64,7 @@
             "type": "text",
             "value": "",
             "group_id": 1,
-            "position": 8,
+            "position": 7,
             "description": "Primary antibody used for immunostaining.",
             "blank_value_on_duplicate": false
         },
@@ -80,7 +72,7 @@
             "type": "text",
             "value": "",
             "group_id": 1,
-            "position": 9,
+            "position": 8,
             "description": "Secondary antibody used for immunostaining.",
             "blank_value_on_duplicate": false
         }

--- a/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_common.json
+++ b/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_common.json
@@ -7,6 +7,7 @@
             }
         ]
     },
+    "extra_fields": {
         "BodyPart": {
             "type": "text",
             "value": "",

--- a/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_common.json
+++ b/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_common.json
@@ -1,0 +1,88 @@
+{
+    "elabftw": {
+        "extra_fields_groups": [
+            {
+                "id": 1,
+                "name": "MODALITY_microscopy_confocal_common"
+            }
+        ]
+    },
+        "NumericalAperture": {
+            "type": "number",
+            "value": "",
+            "group_id": 1,
+            "position": 1,
+            "description": "Lens numerical aperture (e.g. 1.4).",
+            "blank_value_on_duplicate": false
+        },
+        "BodyPart": {
+            "type": "text",
+            "value": "",
+            "group_id": 1,
+            "position": 2,
+            "description": "Body part of the organ / region scanned (e.g. BRAIN).",
+            "blank_value_on_duplicate": false
+        },
+        "BodyPartDetails": {
+            "type": "text",
+            "value": "",
+            "group_id": 1,
+            "position": 3,
+            "description": "Additional details about body part or location.",
+            "blank_value_on_duplicate": false
+        },
+        "SampleEnvironment": {
+            "type": "select",
+            "value": "",
+            "options": [
+                "in vivo",
+                "ex vivo",
+                "in vitro"
+            ],
+            "group_id": 1,
+            "position": 4,
+            "description": "Environment in which the sample was imaged.",
+            "blank_value_on_duplicate": false
+        },
+        "SampleEmbedding": {
+            "type": "text",
+            "value": "",
+            "group_id": 1,
+            "position": 5,
+            "description": "Description of the tissue sample embedding.",
+            "blank_value_on_duplicate": false
+        },
+        "SampleFixation": {
+            "type": "text",
+            "value": "",
+            "group_id": 1,
+            "position": 6,
+            "description": "Description of the tissue sample fixation.",
+            "blank_value_on_duplicate": false
+        },
+        "SampleStaining": {
+            "type": "text",
+            "value": "",
+            "group_id": 1,
+            "position": 7,
+            "description": "Tissue sample staining(s). (within brackets if more than one)",
+            "blank_value_on_duplicate": false
+        },
+        "SamplePrimaryAntibody": {
+            "type": "text",
+            "value": "",
+            "group_id": 1,
+            "position": 8,
+            "description": "Primary antibody used for immunostaining.",
+            "blank_value_on_duplicate": false
+        },
+        "SampleSecondaryAntibody": {
+            "type": "text",
+            "value": "",
+            "group_id": 1,
+            "position": 9,
+            "description": "Secondary antibody used for immunostaining.",
+            "blank_value_on_duplicate": false
+        }
+    }
+}

--- a/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_image_chunk01.json
+++ b/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_image_chunk01.json
@@ -24,6 +24,14 @@
       "description": "Lens immersion medium.",
       "blank_value_on_duplicate": false
     },
+    "chunk01_NumericalAperture": {
+      "type": "number",
+      "value": "",
+      "group_id": 1,
+      "position": 3,
+      "description": "Lens numerical aperture (e.g. 1.4).",
+      "blank_value_on_duplicate": false
+    },
     "chunk01_PixelSize": {
       "type": "text",
       "unit": "",
@@ -34,7 +42,7 @@
       ],
       "value": "",
       "group_id": 1,
-      "position": 3,
+      "position": 4,
       "description": "2- or 3-number array of the physical size of a pixel [X,Y,(Z)]. Unit to be specified on the right!",
       "blank_value_on_duplicate": true
     },
@@ -42,7 +50,7 @@
       "type": "number",
       "value": "",
       "group_id": 1,
-      "position": 4,
+      "position": 5,
       "description": "Lens magnification (e.g. 40).",
       "blank_value_on_duplicate": true
     },
@@ -50,7 +58,7 @@
       "type": "text",
       "value": "",
       "group_id": 1,
-      "position": 5,
+      "position": 6,
       "description": "Description or URI of the image acquisition protocol.",
       "blank_value_on_duplicate": true
     },
@@ -59,7 +67,7 @@
       "value": "",
       "description": "Location of the corresponding data file(s)",
       "group_id": 1,
-      "position": 6,
+      "position": 7,
       "blank_value_on_duplicate": true
     }
   }

--- a/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_image_chunk02.json
+++ b/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_image_chunk02.json
@@ -24,6 +24,14 @@
       "description": "Lens immersion medium.",
       "blank_value_on_duplicate": false
     },
+    "chunk02_NumericalAperture": {
+      "type": "number",
+      "value": "",
+      "group_id": 1,
+      "position": 3,
+      "description": "Lens numerical aperture (e.g. 1.4).",
+      "blank_value_on_duplicate": false
+    },
     "chunk02_PixelSize": {
       "type": "text",
       "unit": "",
@@ -34,7 +42,7 @@
       ],
       "value": "",
       "group_id": 1,
-      "position": 3,
+      "position": 4,
       "description": "2- or 3-number array of the physical size of a pixel [X,Y,(Z)]. Unit to be specified on the right!",
       "blank_value_on_duplicate": true
     },
@@ -42,7 +50,7 @@
       "type": "number",
       "value": "",
       "group_id": 1,
-      "position": 4,
+      "position": 5,
       "description": "Lens magnification (e.g. 40).",
       "blank_value_on_duplicate": true
     },
@@ -50,7 +58,7 @@
       "type": "text",
       "value": "",
       "group_id": 1,
-      "position": 5,
+      "position": 6,
       "description": "Description or URI of the image acquisition protocol.",
       "blank_value_on_duplicate": true
     },
@@ -59,7 +67,7 @@
       "value": "",
       "description": "Location of the corresponding data file(s)",
       "group_id": 1,
-      "position": 6,
+      "position": 7,
       "blank_value_on_duplicate": true
     }
   }

--- a/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_image_chunk03.json
+++ b/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_image_chunk03.json
@@ -24,6 +24,14 @@
       "description": "Lens immersion medium.",
       "blank_value_on_duplicate": false
     },
+    "chunk03_NumericalAperture": {
+      "type": "number",
+      "value": "",
+      "group_id": 1,
+      "position": 3,
+      "description": "Lens numerical aperture (e.g. 1.4).",
+      "blank_value_on_duplicate": false
+    },
     "chunk03_PixelSize": {
       "type": "text",
       "unit": "",
@@ -34,7 +42,7 @@
       ],
       "value": "",
       "group_id": 1,
-      "position": 3,
+      "position": 4,
       "description": "2- or 3-number array of the physical size of a pixel [X,Y,(Z)]. Unit to be specified on the right!",
       "blank_value_on_duplicate": true
     },
@@ -42,7 +50,7 @@
       "type": "number",
       "value": "",
       "group_id": 1,
-      "position": 4,
+      "position": 5,
       "description": "Lens magnification (e.g. 40).",
       "blank_value_on_duplicate": true
     },
@@ -50,7 +58,7 @@
       "type": "text",
       "value": "",
       "group_id": 1,
-      "position": 5,
+      "position": 6,
       "description": "Description or URI of the image acquisition protocol.",
       "blank_value_on_duplicate": true
     },
@@ -59,7 +67,7 @@
       "value": "",
       "description": "Location of the corresponding data file(s)",
       "group_id": 1,
-      "position": 6,
+      "position": 7,
       "blank_value_on_duplicate": true
     }
   }

--- a/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_image_chunk04.json
+++ b/template_parts/Bids_modality_specific/MODALITY_microscopy_confocal_image_chunk04.json
@@ -24,6 +24,14 @@
       "description": "Lens immersion medium.",
       "blank_value_on_duplicate": false
     },
+    "chunk04_NumericalAperture": {
+      "type": "number",
+      "value": "",
+      "group_id": 1,
+      "position": 3,
+      "description": "Lens numerical aperture (e.g. 1.4).",
+      "blank_value_on_duplicate": false
+    },
     "chunk04_PixelSize": {
       "type": "text",
       "unit": "",
@@ -34,7 +42,7 @@
       ],
       "value": "",
       "group_id": 1,
-      "position": 3,
+      "position": 4,
       "description": "2- or 3-number array of the physical size of a pixel [X,Y,(Z)]. Unit to be specified on the right!",
       "blank_value_on_duplicate": true
     },
@@ -42,7 +50,7 @@
       "type": "number",
       "value": "",
       "group_id": 1,
-      "position": 4,
+      "position": 5,
       "description": "Lens magnification (e.g. 40).",
       "blank_value_on_duplicate": true
     },
@@ -50,7 +58,7 @@
       "type": "text",
       "value": "",
       "group_id": 1,
-      "position": 5,
+      "position": 6,
       "description": "Description or URI of the image acquisition protocol.",
       "blank_value_on_duplicate": true
     },
@@ -59,7 +67,7 @@
       "value": "",
       "description": "Location of the corresponding data file(s)",
       "group_id": 1,
-      "position": 6,
+      "position": 7,
       "blank_value_on_duplicate": true
     }
   }


### PR DESCRIPTION
- updated GENERAL_participant-animal-short to address https://github.com/INT-NIT/elabforms_BIDSMetadata/issues/17
- created MODALITY_microscopy_confocal_common to remove some fields from MODALITY_microscopy 

I have one question left about the NumericalAperture metadata (https://bids-specification.readthedocs.io/en/stable/glossary.html#numericalaperture-metadata): is it common to all images (and therefore it should be added to MODALITY_microscopy_confocal_common)? or can it be different between images recorded on the same slice (and therefore it should be added to all the chunks)? I would go with the latter but I'm waiting for the confirmation of our microscopy experts...